### PR TITLE
Set timezone for shelf-reading app

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
     environment:
         # tell gunicorn/flask we're putting this behind a path
         SCRIPT_NAME: /shelf-reading
+        TZ: America/New_York
     healthcheck:
       start_period: 1s
   folio-shelving-order:


### PR DESCRIPTION
Lending services folks noticed that the shelf reading app's log messages had timestamps in the wrong timezone.  Seems like docker defaults to UTC (which makes sense).